### PR TITLE
Feat train sklearn

### DIFF
--- a/fpl_ml/log.py
+++ b/fpl_ml/log.py
@@ -1,0 +1,43 @@
+import mlflow
+import torch
+from typing import Optional, Callable
+from torchmetrics import Metric
+
+
+def log_metrics_and_visualisations(
+    y_true: torch.Tensor,
+    y_pred: torch.Tensor,
+    stage: str,
+    metrics: Optional[dict[str, Metric]],
+    visualisations: Optional[dict[str, Callable]],
+) -> dict[str, float]:
+    """Standardised logging of metrics and visualisations with mlflow
+
+    Args:
+        y_true: True data.
+        y_pred: Predicted data from model.
+        stage: Stage of workflow (train, val, test).
+        metrics: Dictionary of torchmetrics.
+        visualisations: Dictionary of visualisation functions.
+
+    Returns:
+        Dictionary of metrics names and their values
+    """
+
+    eval_metrics = {}
+
+    if metrics:
+        # Iterate, compute and log validation metrics
+        for m in metrics.keys():
+            met = metrics[m](y_pred, y_true)
+            mlflow.log_metric(f"{stage}_{m}", met)
+
+            eval_metrics[f"{stage}_{m}"] = met
+
+    if visualisations:
+        # Apply visualisation steps to validation data
+        for vis_key in visualisations.keys():
+            fig = visualisations[vis_key](y_true=y_true, y_pred=y_pred)
+            mlflow.log_figure(fig, f"{stage}_{vis_key}.html")
+
+    return eval_metrics

--- a/fpl_ml/sklearn_lightning_wrapper.py
+++ b/fpl_ml/sklearn_lightning_wrapper.py
@@ -1,4 +1,3 @@
-from pyexpat import features
 from typing import Union, Callable
 
 import torch

--- a/fpl_ml/sklearn_lightning_wrapper.py
+++ b/fpl_ml/sklearn_lightning_wrapper.py
@@ -1,0 +1,90 @@
+from pyexpat import features
+from typing import Union, Callable
+
+import torch
+
+
+import numpy as np
+import pytorch_lightning as pl
+from sklearn.base import ClassifierMixin, RegressorMixin
+from torchmetrics.metric import Metric
+
+from fpl_ml.log import log_metrics_and_visualisations
+
+class SklearnModel:
+    """Wrapper for sklearn models for standardised logging."""
+
+    def __init__(
+        self,
+        model: Union[ClassifierMixin, RegressorMixin],
+        metrics: dict[str, Metric],
+        visualisations: dict[str, Callable],
+        features_key: str = 'X',
+        labels_key: str = 'y'
+    ):
+        self.model = model
+        self._metrics = metrics
+        self._visualisations = visualisations
+
+        self._features_key = features_key
+        self._labels_key = labels_key
+
+    def __call__(self, batch):
+        if self.model._estimator_type == "regressor":
+            return self.model.predict(batch)
+        elif self.model._estimator_type == "classifier":
+            return self.model.predict_proba(batch)
+
+    def fit(self, data_module: pl.LightningDataModule) -> dict[str, float]:
+        """Fits sklearn model and logs metrics and visualisations on the training
+        and validation data.
+
+        Args:
+            data_module: Datamodule containing training and validation data
+
+        Returns:
+            Dictionary of metric names and their values
+        """
+
+        # Fit model using whole train dataset
+        train_batch = data_module.train_dataloader().dataset[:]
+        self.model.fit(X=train_batch[self._features_key], y=train_batch[self._labels_key])
+
+        # Log metrics and figures for train data
+        output_metrics = self._log(batch=train_batch, stage="train")
+
+        # Log metrics and figures for validation data
+        val_batch = data_module.val_dataloader().dataset[:]
+        output_metrics = self._log(batch=val_batch, stage="val")
+
+        return output_metrics
+
+    def _log(self, batch: dict[str, np.ndarray], stage: str):
+        y_true = batch[self._labels_key]
+
+        if self.model._estimator_type == "regressor":
+            y_pred = self.model.predict(batch[self._features_key])
+
+            # Reshape output of prediction for torchmetrics compatibility when we have
+            # a single output
+            if y_true.shape[1] == 1:
+                y_pred = y_pred.reshape(-1, 1)
+
+        else:
+            raise NotImplementedError(
+                f"Metric logging for estimator type: {self.model._estimator_type} not yet implemented"
+            )
+
+        # Move to pytorch tensor for torchmetrics compatibility
+        y_true = torch.from_numpy(y_true)
+        y_pred = torch.from_numpy(y_pred)
+
+        output_metrics = log_metrics_and_visualisations(
+            y_true,
+            y_pred,
+            stage=stage,
+            metrics=self._metrics,
+            visualisations=self._visualisations,
+        )
+
+        return output_metrics

--- a/fpl_ml/train.py
+++ b/fpl_ml/train.py
@@ -1,0 +1,43 @@
+import lightning.pytorch as pl
+from typing import Optional, Union, Callable
+from sklearn.base import ClassifierMixin, RegressorMixin
+from torchmetrics import Metric
+import mlflow
+from fpl_ml.utils import set_random_seeds
+from fpl_ml.sklearn_lightning_wrapper import SklearnModel
+
+
+def train_sklearn(
+    data_module: pl.LightningDataModule,
+    model: Union[ClassifierMixin, RegressorMixin],
+    metrics: dict[str, Metric],
+    experiment_name: str,
+    visualisations: dict[str, Callable],
+    return_validation_metrics: Optional[list[str]] = None,
+    random_seed: Union[int, None] = None,
+) -> Union[float, tuple, None]:
+    mlflow.set_experiment(experiment_name=experiment_name)
+    experiment = mlflow.get_experiment_by_name(experiment_name)
+
+    # Initialise model
+    model = SklearnModel(model, metrics, visualisations)
+
+
+    with mlflow.start_run(experiment_id=experiment.experiment_id):
+        mlflow.sklearn.autolog()
+        
+        # Seed everything and log the seed
+        random_seed = set_random_seeds(random_seed)
+        mlflow.log_param("seed", random_seed)
+
+        # Fit model
+        output_metrics = model.fit(data_module)
+
+    # Optionally return metrics for hyperparameter optimization
+    if return_validation_metrics:
+        ret_metrics = tuple(output_metrics[x] for x in return_validation_metrics)
+
+        if len(ret_metrics) == 1:
+            return ret_metrics[0]
+
+        return ret_metrics

--- a/fpl_ml/utils.py
+++ b/fpl_ml/utils.py
@@ -1,0 +1,47 @@
+from typing import Optional, cast
+from lightning.pytorch import seed_everything
+import time
+import pandas as pd
+
+def set_random_seeds(random_seed: Optional[int]) -> int:
+    """Sets random seed using provided integer.
+
+    If argument is None, generates a pseudo random seed
+    to use.
+
+    Args:
+        random_seed (Union[int, None]): Seed to use, or None to use pseudo random seed
+
+    Returns:
+        int: Seed used to set everything
+    """
+
+    if not random_seed:
+        t = 1000 * time.time()  # current time in milliseconds
+        random_seed = int(t) % 2**32
+
+    random_seed = cast(int, random_seed)
+
+    seed_everything(random_seed)
+
+    return random_seed
+
+
+def get_columns_with_prefix(df: pd.DataFrame, prefix_list: list[str]) -> list[str]:
+    """Returns columns of the dataframe that start with a provided prefix
+
+    Args:
+        df (pd.DataFrame): dataframe
+        prefix_list (list[str]): prefixes used to extract columns
+
+    Returns:
+        list[str]: list of columns starting with prefix
+    """
+    return list(df.columns[df.columns.str.startswith(tuple(prefix_list))])
+
+
+def add_prefix_to_columns(df, columns, prefix):
+    new_names = {i: prefix + i for i in columns}
+    df = df.rename(columns=new_names)
+
+    return df


### PR DESCRIPTION
Landing code for wrapping sklearn models into a standardised framework of metric logging and visualisation logging.

### Metrics
All metrics should be from torchmetrics, although we use sklearn here we will also be supporting torch models later

We follow the pytorch-lightning framework giving our metrics a prefix of `'train_', 'val_'` or `'test_'`depending on the stage. These prefixes are using when logging to mlflow e.g `val_MSE`